### PR TITLE
Replace flag imports with spf13/pflag in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ See `examples/` for more.
 package main
 
 import (
-    "flag"
     "fmt"
 
+    "github.com/spf13/pflag"
     "go.coder.com/cli"
 )
 
@@ -78,9 +78,9 @@ simple-example flags:
 package main
 
 import (
-    "flag"
     "fmt"
 
+    "github.com/spf13/pflag"
     "go.coder.com/cli"
 )
 


### PR DESCRIPTION
The README's code examples import flag, but use pflag instead.

This just reflects the change in imports.