### PR TITLE
Small style adjustments to command tests

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -9,28 +9,20 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const (
-	success = "test successful"
-
-	expectedParentCmdHelpOutput = `Usage: mockParentCmd Mock parent command usage.
-
-Mock parent command description.
-
-Commands:
-	s,sc,sub,mockSubCmd  - A simple mock subcommand with aliases.
-`
-)
-
-var subCmd = &mockSubCmd{buf: new(bytes.Buffer)}
+var subCmd = new(mockSubCmd)
 
 type (
 	mockParentCmd struct{}
-	mockSubCmd    struct{ buf *bytes.Buffer }
+	mockSubCmd    struct {
+		buf *bytes.Buffer
+	}
 )
 
 func (c *mockParentCmd) Run(fl *pflag.FlagSet) {}
 
-func (c *mockParentCmd) Subcommands() []Command { return []Command{subCmd} }
+func (c *mockParentCmd) Subcommands() []Command {
+	return []Command{subCmd}
+}
 
 func (c *mockParentCmd) Spec() CommandSpec {
 	return CommandSpec{
@@ -42,12 +34,15 @@ func (c *mockParentCmd) Spec() CommandSpec {
 
 func (c *mockSubCmd) Run(fl *pflag.FlagSet) {
 	c.buf = new(bytes.Buffer)
-	if _, err := c.Write([]byte(success)); err != nil {
+	_, err := c.WriteString("success")
+	if err != nil {
 		fl.Usage()
 	}
 }
 
-func (c *mockSubCmd) Write(b []byte) (int, error) { return c.buf.Write(b) }
+func (c *mockSubCmd) WriteString(s string) (int, error) {
+	return c.buf.WriteString(s)
+}
 
 func (c *mockSubCmd) Spec() CommandSpec {
 	return CommandSpec{
@@ -59,47 +54,38 @@ func (c *mockSubCmd) Spec() CommandSpec {
 }
 
 func TestSubCmdAliases(t *testing.T) {
-	for _, test := range []struct {
-		name, expected string
-	}{
-		{
-			name:     "s",
-			expected: success,
-		},
-		{
-			name:     "sc",
-			expected: success,
-		},
-		{
-			name:     "sub",
-			expected: success,
-		},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			// Since the alias is the name of the test
-			// we can just pass it as the alias arg.
-			os.Args = []string{"mockParentCmd", test.name}
-			// Based on os.Args, when splitArgs is invoked,
-			// it should be able to deduce the subcommand we want
-			// based on the new alias map it's being passed.
-			RunRoot(&mockParentCmd{})
-			// The success const is never written into the buffer
-			// if the subcommand fails to be invoked by alias.
+	for _, alias := range []string{"s", "sc", "sub"} {
+		t.Run(alias, func(t *testing.T) {
+			// Setup command.
+			cmd := new(mockParentCmd)
+			os.Args = []string{cmd.Spec().Name, alias}
+			// Run command.
+			RunRoot(cmd)
+			// If "success" isn't written into the buffer
+			// then we failed to find the subcommand by alias.
 			got := string(subCmd.buf.Bytes())
-			assert.Equal(t, test.name, test.expected, got)
+			assert.Equal(t, t.Name(), "success", got)
 		})
 	}
 }
 
-func TestSubcmdAliasesInParentCmdHelpOutput(t *testing.T) {
-	buf := new(bytes.Buffer)
-	cmd := &mockParentCmd{}
-	name := cmd.Spec().Name
-	fl := pflag.NewFlagSet(name, pflag.ExitOnError)
-	// If the help output is not written to the buffer
-	// in the format we expect then the test will fail.
-	renderHelp(name, cmd, fl, buf)
-	got := string(buf.Bytes())
-	expected := expectedParentCmdHelpOutput
-	assert.Equal(t, "display_subcmd_aliases_in_parentcmd_help_output", expected, got)
+func TestCmdHelpOutput(t *testing.T) {
+	t.Run(t.Name(), func(t *testing.T) {
+		expected := `Usage: mockParentCmd Mock parent command usage.
+
+Mock parent command description.
+
+Commands:
+	s,sc,sub,mockSubCmd  - A simple mock subcommand with aliases.
+`
+		buf := new(bytes.Buffer)
+		cmd := new(mockParentCmd)
+		name := cmd.Spec().Name
+		fl := pflag.NewFlagSet(name, pflag.ExitOnError)
+		// If the help output doesn't contain the subcommand and
+		// isn't formatted the way we expect the test will fail.
+		renderHelp(name, cmd, fl, buf)
+		got := string(buf.Bytes())
+		assert.Equal(t, t.Name(), expected, got)
+	})
 }


### PR DESCRIPTION
Revisited these tests to make some minor code style adjustments.

**Why?**

They were pointed out to me and made sense.

**What was changed?**

- Replaced `Write` with `WriteString` to get rid of a type-cast.
- Moved some globals that were only used once into the blocks they're used in.
- Shorten func name `TestSubcmdAliasesInParentCmdHelpOutput` to `TestCmdHelpOutput`.
- Reduce line length in a few areas.
- Use `new` for initializing pointers consistently.

**Tests still pass?**

Yes

```
=== RUN   TestSubCmdAliases
=== RUN   TestSubCmdAliases/s
=== RUN   TestSubCmdAliases/sc
=== RUN   TestSubCmdAliases/sub
--- PASS: TestSubCmdAliases (0.00s)
    --- PASS: TestSubCmdAliases/s (0.00s)
    --- PASS: TestSubCmdAliases/sc (0.00s)
    --- PASS: TestSubCmdAliases/sub (0.00s)
=== RUN   TestCmdHelpOutput
=== RUN   TestCmdHelpOutput/TestCmdHelpOutput
--- PASS: TestCmdHelpOutput (0.00s)
    --- PASS: TestCmdHelpOutput/TestCmdHelpOutput (0.00s)
PASS
ok      go.coder.com/cli        0.376s
```