### PR TITLE
nits: update readme and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A minimal, command-oriented CLI package.
 - Very small, simple API.
 - Support for POSIX flags.
 - Only external dependency is [spf13/pflag](https://github.com/spf13/pflag).
-- Subcommands.
+- Subcommands and subcommand aliases.
 - Auto-generated help.
 
 ## Install
@@ -135,5 +135,5 @@ Usage: subcommand [flags]
 This is a simple example of subcommands.
 
 Commands:
-	s,sub -	This is a simple subcommand.
+	s, sub  - This is a simple subcommand.
 ```

--- a/command_test.go
+++ b/command_test.go
@@ -82,7 +82,7 @@ func TestSubCmdAliases(t *testing.T) {
 			RunRoot(cmd)
 			// If "success" isn't written into the buffer
 			// then we failed to find the subcommand by alias.
-			got := string(subCmd.buf.Bytes())
+			got := subCmd.buf.String()
 			assert.Equal(t, t.Name(), "success", got)
 		})
 	}


### PR DESCRIPTION
# What this does?

I updated the readme so the spacing between subcommands and their aliases in the output is accurate as well as a nit in the command test where we weren't converting the expected output into a string the same way we were doing so for the other tests.